### PR TITLE
Fix bind conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ TOOD: use toml
 
 In the `servers` section, you can define multiple `server` objects:
 
-| Field  |  Type  |                                                     Description                                                     |
-|:------:|:------:|:-------------------------------------------------------------------------------------------------------------------:|
-| `host` | string | `IP:port` or `domain-name:port` of the origin server. Port can be ommitted, in which case it will default to 25565. |
+|      Field       |   Type   |                                                     Description                                                     |
+|:----------------:|:--------:|:-------------------------------------------------------------------------------------------------------------------:|
+|      `host`      |  string  | `IP:port` or `domain-name:port` of the origin server. Port can be ommitted, in which case it will default to 25565. |
+|      `bind`      | string[] |        Socket addresses to bind. Default is `[::]:25565`. Note: IPv6 wildcard bind `::` will contains IPv4.         |
+| `proxy_protocol` |   bool   |                                     Enable Proxy Protocol v2. Default is false.                                     |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ I created this for learning rust and TCP/IP programming.
 - SRV Record Support
 - Sanity Checks (e.g. panic when binding to the same address:port)
 
-## Configuration
+## Configuration (WIP)
 
-Refer to the [examples](examples) for configurations.
+Refer to the [examples](examples) for example configurations.
+
+TOOD: use toml
+
+### servers
+
+In the `servers` section, you can define multiple `server` objects:
+
+| Field  |  Type  |                                                     Description                                                     |
+|:------:|:------:|:-------------------------------------------------------------------------------------------------------------------:|
+| `host` | string | `IP:port` or `domain-name:port` of the origin server. Port can be ommitted, in which case it will default to 25565. |

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,6 +1,6 @@
 servers:
   vanilla_server:
-    # if no 'bind' found, it binds to "0.0.0.0:25565" and "[::]:25565"
+    # if no 'bind' found, it binds "[::]:25565"
     server: "minecraft.example.com" # Port defaults to 25565
   modded_server:
     proxy_protocol: true # Enable proxy protocol v2

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -18,7 +18,7 @@ pub struct ProxyConfig {
     #[serde(default = "default_bind")]
     pub bind: Vec<SocketAddr>,
     #[serde(deserialize_with = "deserialize_server")]
-    pub server: SocketAddr,
+    pub host: SocketAddr,
     #[serde(default)] // Default to false
     pub proxy_protocol: bool,
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -79,9 +79,8 @@ where
     }
 }
 
+/// Default bind address for the proxy server.
+/// `[::]:25565` will also bind to IPv4, so there is no `0.0.0.0:25565`.
 fn default_bind() -> Vec<SocketAddr> {
-    vec![
-        "0.0.0.0:25565".parse().unwrap(),
-        "[::]:25565".parse().unwrap(),
-    ]
+    vec!["[::]:25565".parse().unwrap(), ]
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
         for bind_addr in proxy.bind {
             handlers.push(tokio::spawn(proxy_tcp(
                 bind_addr,
-                proxy.server,
+                proxy.host,
                 proxy.proxy_protocol,
                 rx.clone(),
                 config.sorry_server.clone(),
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
         }
         if config.health_check.enabled {
             handlers.push(tokio::spawn(health_check::activate_health_check_for(
-                proxy.server,
+                proxy.host,
                 tx,
                 config.health_check.interval(),
                 config.health_check.timeout(),

--- a/src/mcp/ping.rs
+++ b/src/mcp/ping.rs
@@ -10,7 +10,7 @@ pub struct Response {
 }
 
 impl Response {
-    pub fn from_config(config: SorryServerConfig) -> Response {
+    pub fn from_config(config: SorryServerConfig) -> Self {
         let version = Version {
             name: config.version,
             protocol: DEFAULT_PROTOCOL,
@@ -26,7 +26,7 @@ impl Response {
             text: config.motd.join("\n"),
         };
 
-        Response {
+        Self {
             version,
             players,
             description,

--- a/src/proxy_protocol.rs
+++ b/src/proxy_protocol.rs
@@ -43,14 +43,14 @@ struct ProxyHeaderV2 {
 }
 
 impl ProxyHeaderV2 {
-    fn create_v4(command: CommandV2, transport: TransportProtocol) -> ProxyHeaderV2 {
+    fn create_v4(command: CommandV2, transport: TransportProtocol) -> Self {
         let af_and_transport = match transport {
             TransportProtocol::Unspec => AF_INET | TRANSPORT_UNSPEC,
             TransportProtocol::Stream => AF_INET | TRANSPORT_STREAM,
             TransportProtocol::Dgram => AF_INET | TRANSPORT_DGRAM,
         };
         let length = 12;
-        ProxyHeaderV2 {
+        Self {
             sig: <[u8; 12]>::try_from(PROXY_PROTOCOL_START).unwrap(),
             version_and_command: command.get_num(),
             af_and_transport,
@@ -58,14 +58,14 @@ impl ProxyHeaderV2 {
         }
     }
 
-    fn create_v6(command: CommandV2, transport: TransportProtocol) -> ProxyHeaderV2 {
+    fn create_v6(command: CommandV2, transport: TransportProtocol) -> Self {
         let af_and_transport = match transport {
             TransportProtocol::Unspec => AF_INET6 | TRANSPORT_UNSPEC,
             TransportProtocol::Stream => AF_INET6 | TRANSPORT_STREAM,
             TransportProtocol::Dgram => AF_INET6 | TRANSPORT_DGRAM,
         };
         let length = 36;
-        ProxyHeaderV2 {
+        Self {
             sig: <[u8; 12]>::try_from(PROXY_PROTOCOL_START).unwrap(),
             version_and_command: command.get_num(),
             af_and_transport,


### PR DESCRIPTION
`::`はv4含むケースがあるのでデフォルトを`::`だけに変更。

加えて、`Self`を使える箇所ではそれを使う。